### PR TITLE
add missing build_depend in package.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ This packages allow you generating collision-free trajectory based on your map. 
     To realize global navigation, RRT/RRT* planner is used the global planner in this [repo](https://github.com/Zhefan-Xu/global_planner). It is not required if you want to write your own code using this repo. It is just for navigation demo.
     ```
     cd ~/catkin_ws/src
-    git clone https://github.com/Zhefan-Xu/global_planner.git # OPTIONAL (ONLY required if you want to play with our demo)
-    git clone https://github.com/Zhefan-Xu/trajectory_planner.git
+    git clone https://github.com/maxibooksiyi/global_planner.git # MANDATORY: it is a build dependency for this package
+    git clone https://github.com/TDNPP/trajectory_planner.git
 
     # make
     cd ~/catkin_ws

--- a/package.xml
+++ b/package.xml
@@ -52,6 +52,8 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>global_planner</build_depend>
+
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>

--- a/src/polyRRTGoalNode.cpp
+++ b/src/polyRRTGoalNode.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv){
 	std::thread goalVisWorker_ = std::thread(publishGoalVis);
 	
 	const int N = 3; // dimension
-	globalPlanner::rrtOctomap<N> rrtplanner (nh);
+	globalPlanner::rrtOctomap<N> rrtplanner {};
 	cout << rrtplanner << endl;
 
 	trajPlanner::polyTrajOctomap polyPlanner (nh);

--- a/src/polyRRTNode.cpp
+++ b/src/polyRRTNode.cpp
@@ -56,8 +56,8 @@ int main(int argc, char** argv){
 	std::thread goalVisWorker_ = std::thread(publishGoalVis);
 	
 	const int N = 3; // dimension
-	globalPlanner::rrtOctomap<N> rrtplanner (nh);
-	cout << rrtplanner << endl;
+	globalPlanner::rrtOctomap<N> rrtplanner {};
+	cout << &rrtplanner << endl;
 
 	trajPlanner::polyTrajOctomap polyPlanner (nh);
 	cout << polyPlanner << endl;

--- a/src/polyRRTStarNode.cpp
+++ b/src/polyRRTStarNode.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv){
 	std::thread goalVisWorker_ = std::thread(publishGoalVis);
 	
 	const int N = 3; // dimension
-	globalPlanner::rrtStarOctomap<N> rrtStarPlanner (nh);
+	globalPlanner::rrtStarOctomap<N> rrtStarPlanner {};
 	cout << rrtStarPlanner << endl;
 
 	trajPlanner::polyTrajOctomap polyPlanner (nh);


### PR DESCRIPTION
I couldn't compile using `catkin build` without adding the `build_depend` to the global planner, now it finds the correct headers